### PR TITLE
Misc updates: styles, accessibility

### DIFF
--- a/src/controllers/ctl-player.js
+++ b/src/controllers/ctl-player.js
@@ -54,6 +54,10 @@ export const onMateriaStart = ($scope, $sce, instance, qset, version) => {
 	_qset = qset
 	_qset.version = version
 
+	console.log(instance.name)
+
+	$scope.gameTitle = instance.name
+
 	if (_qset.options && _qset.options.randomizeOrder === true) {
 		shuffleArray(_qset.items)
 	}

--- a/src/directives/dir-focus.js
+++ b/src/directives/dir-focus.js
@@ -3,7 +3,7 @@ export const DirectiveFocus = ['$timeout', '$parse', ($timeout, $parse) => ({
 		const model = $parse(attrs.focusMe)
 		scope.$watch(model, function(value) {
 			if (value) {
-				$timeout(() => element[0].focus())
+				$timeout(() => element[0].focus(), 650, true)
 			}
 		})
 	}

--- a/src/player.html
+++ b/src/player.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" ng-app="ThisOrThatEngine" ng-controller="ThisOrThatEngineCtrl" ng-keydown="selectChoice($event)">
+<html lang="en">
 	<head>
 		<title>This Or That Engine</title>
 		<meta charset="utf-8">
@@ -7,8 +7,9 @@
 		<meta name="apple-mobile-web-app-capable" content="yes">
 
 		<!-- STYLESHEETS -->
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Sigmar+One&display=swap">
-		<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Buenard:700">
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Buenard:wght@700&family=Sigmar+One&display=swap" rel="stylesheet">
 		<link rel="stylesheet" href="player.css">
 
 		<!-- REQUIRED MATERIA JAVASCRIPT -->
@@ -21,12 +22,11 @@
 		<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.7.9/angular-sanitize.min.js"></script>
 		<script src="assets/js/hammer.min.js"></script>
 		<script src="assets/js/angular-hammer.min.js"></script>
-		<script src="assets/js/modernizr.min.js"></script>
 
 		<!-- MAIN WIDGET SCRIPT -->
 		<script src="player.js"></script>
 	</head>
-	<body>
+	<body ng-app="ThisOrThatEngine" ng-controller="ThisOrThatEngineCtrl" ng-keydown="selectChoice($event)">
 
 		<!-- aria-live region to report status updates -->
 		<!-- note: browser support for aria-live is mixed, behavior may be inconsistent across browsers and devices -->
@@ -38,27 +38,14 @@
 
 				<div
 					class="sign"
-					ng-class="{'raised': gameState.ingame, 'end': gameState.endgame}"
-					role="{{gameState.endgame ? 'alertdialog' : 'dialog'}}"
-					aria-modal="true"
-					aria-hidden="{{focusStatusButton}}"
-					ng-attr-inert="{{gameState.ingame || focusStatusButton || instructionsOpen ? 'true' : undefined }}">
-					<h1 id="splashText" aria-label="Welcome to {{gameState.splashText}}"aria-hidden="{{gameState.ingame}}">{{gameState.splashText}}</h1>
+					ng-class="{'raised': gameState.ingame, 'end': gameState.endgame}">
+					<h1 id="splashText">{{gameState.splashText}}</h1>
 
 					<div class="start-btns">
 						<button class="start btn"
-						id="instructions-btn"
-						ng-click="toggleInstructions()"
-						aria-hidden="{{gameState.endgame || gameState.ingame }}"
-						ng-attr-inert="{{gameState.endgame ? 'true' : undefined}}"
-						focus-me="!instructionsOpen"
-						aria-label="Keyboard controls: Press A to select the first choice. Press D to select the second choice. Then, click to lock in your answer. Press Q to hear the question again. Press H to open the instructions. You may also navigate using your screen reader's dedicated key bindings."
-						ng-hide="gameState.endgame || gameState.ingame">
-							Keyboard Controls
-						</button>
-						<button class="start btn"
 							id="start-btn"
 							ng-click="closeIntro()"
+							aria-label="Welcome to This or That! Press the H key at any time to view the keyboard instructions modal. Press space or enter to begin."
 							aria-hidden="{{gameState.endgame || gameState.ingame }}"
 							ng-attr-inert="{{gameState.endgame || gameState.ingame ? 'true' : undefined}}"
 							ng-hide="gameState.endgame || gameState.ingame">
@@ -277,16 +264,16 @@
 					<div class="hand that-hand"
 						ng-class="{'raised': hands.thatRaised || question.choice == 1, 'correct': question.correct[1] == 'Correct!', 'incorrect': question.correct[1] == 'Incorrect'}"></div>
 				</div>
-
-				<div id="next-container" ng-class="{'raised': gameState.showNext}" aria-hidden="{{(!gameState.showNext && question.transition == false) || lightboxTarget >= 0}}">
-					<div class="background-stand" aria-hidden="true"></div>
-					<button class="btn"
-						id="next"
-						ng-click="nextClicked()"
-						focus-me="gameState.showNext"
-						ng-attr-inert="{{!gameState.showNext || lightboxTarget >= 0 ? 'true' : undefined}}">Next</button>
-				</div>
 			</section>
+
+			<div id="next-container">
+				<button class="btn"
+					id="next"
+					ng-click="nextClicked()"
+					ng-class="{'raised': gameState.showNext}" aria-hidden="{{(!gameState.showNext && question.transition == false) || lightboxTarget >= 0}}"
+					ng-attr-inert="{{!gameState.showNext || lightboxTarget >= 0 ? 'true' : undefined}}">Next</button>
+			</div>
+
 			<section class="lightbox" ng-class="{ 'show': lightboxTarget >= 0}" ng-hide="lightboxTarget == -1" aria-modal="true">
 				<div class="lightbox-content">
 					<button class="lightbox-close" ng-click="setLightboxTarget(-1)" aria-label="Close image" focus-me="lightboxTarget >= 0">X</button>

--- a/src/player.scss
+++ b/src/player.scss
@@ -3,9 +3,6 @@
 * {
 	transform-style: flat;
 }
-html {
-	height: 100%;
-}
 
 // Color palette.
 $a: #223863;
@@ -19,7 +16,7 @@ $x: rgba(110, 199, 47, 0.9);
 $y: #ffb743;
 $z: #ffa30f;
 
-$chunky-font: 'Sigmar One', cursive;
+$chunky-font: 'Sigmar One', sans-serif;
 
 body {
 	color: #fff;
@@ -28,17 +25,25 @@ body {
 	background-repeat: no-repeat;
 	padding: 0;
 	margin: 0;
-	width: 800px;
-	min-height: 520px;
+	width: 100%;
+	height: 100%;
+	min-height: 515px;
 	font-family: $chunky-font;
-	overflow-x: hidden;
-	overflow-y: hidden;
 	cursor: default;
 
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+
+	main {
+		position: absolute;
+		top: 0px;
+		width: 100%;
+		height: 515px;
+		overflow-x: hidden;
+		overflow-y: hidden;
+	}
 }
 
 .btn {
@@ -57,7 +62,7 @@ body {
 	border: 0;
 	border-radius: 8px;
 	box-shadow: 0 6px 6px rgba(0, 0, 0, 0.3);
-	outline: none;
+	outline: solid 2px #73d15a;
 
 	cursor: pointer;
 	-webkit-appearance: none;
@@ -133,9 +138,18 @@ body {
 }
 
 #board {
-	text-align: center;
+	position: absolute;
+	top: 0;
+	left: 0;
+
+	margin-bottom: 200px;
+	
 	width: 800px;
-	//height: 520px;
+	height: 515px;
+	overflow-x: hidden;
+	overflow-y: hidden;
+
+	text-align: center;
 
 	#question {
 		margin: 68px auto 20px auto;
@@ -150,9 +164,16 @@ body {
 
 #assistive-alert {
 	position: absolute;
+	display: inline-block;
+	top: 0;
+	left: 0;
 	width: 0;
 	height: 0;
 	opacity: 0;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
+	transform: translate (-999px,0);
 }
 
 .error-notice-container {
@@ -189,10 +210,10 @@ body {
 
 #splash {
 	position: absolute;
-	left: 0;
-	right: 0;
-	top: 0;
-	bottom: 0;
+	left: 0px;
+	top: 0px;
+	width: 100%;
+	height: 100vh;
 	background-image: url('assets/img/sprites.png');
 	background-position: -56px bottom;
 
@@ -295,11 +316,12 @@ body {
 }
 
 #choices {
+	z-index: 0;
 	display: flex;
 	width: 750px;
 	height: 302px;
 	margin: 0 auto;
-	z-index: 0;
+	
 	transform-style: flat;
 
 	.stand-container {
@@ -365,7 +387,7 @@ body {
 
 				.overlayFeedback {
 					text-shadow: 0 4px 2px rgba(0, 0, 0, 0.6);
-					background-color: $x;
+					background-color: rgba(57, 142, 0, 0.9);
 				}
 			}
 
@@ -692,64 +714,59 @@ body {
 }
 
 #next-container {
+	z-index: 4000;
 	position: absolute;
-	right: 40px;
-
-	bottom: 100px;
-	opacity: 0;
-	height: 75px;
-	width: 95px;
-
-	transition: bottom ease 0.3s;
-
-	&.raised {
-		//animation: bouncy-in-next 0.6s;
-		//animation-fill: forwards;
-		bottom: 0;
-		display: block;
-		opacity: 1;
-	}
-
-	.background-stand {
-		position: absolute;
-		top: 0;
-		left: 50%;
-
-		margin-left: -5px;
-		height: 75px;
-		width: 10px;
-
-		background-image: url('assets/img/sprites.png');
-		background-position: -67px -146px, center top;
-		background-repeat: no-repeat;
-	}
+	bottom: -335px;
+	right: 48px;
+	height: 400px;
+	width: 200px;
 
 	#next {
+		display: block;
+		width: 110px;
+		height: 52px;
+		margin-left: 88px;
+		margin-top: 200px;
 		padding: 6px 14px;
 
 		font-size: 24px;
-
-		//animation: pulse-bg 1s infinite;
-
-		z-index: 4;
-
+	
+		transition: margin-top 0.5s;
+	
+		&.raised {
+			margin-top: 0px;
+		}
+	
+		&:after {
+			position: absolute;
+			display: block;
+			content: '';
+			top: 54px;
+			left: 45px;
+	
+			height: 75px;
+			width: 10px;
+	
+			background-image: url('assets/img/sprites.png');
+			background-position: -67px -146px, center top;
+			background-repeat: no-repeat;
+		}
+	
 		&:focus {
 			outline: solid 2px #fff;
 		}
 	}
 }
 .start-btns {
-	display: flex;
-	flex-direction: column;
-	gap: 20px;
-	margin-top: 10px;
+	display: block;
+	margin-top: 60px;
 	align-items: center;
 }
 
 #ingame-instructions-btn {
 	position: absolute;
 	top: -100px;
-	left: 25px;
+	left: 15px;
 	z-index: 10;
 	width: 48px;
 	height: 48px;
@@ -779,7 +796,7 @@ body {
 #questions-remaining {
 	position: absolute;
 	top: -100px;
-	right: 25px;
+	right: 15px;
 	z-index: 10;
 	background: none;
 	border: none;
@@ -801,7 +818,7 @@ body {
 		border-radius: 100%;
 		box-shadow: 0px 5px 10px $a;
 
-		font-family: $chunky-font;
+		// font-family: $chunky-font;
 
 		position: relative;
 		display: flex;
@@ -832,8 +849,6 @@ body {
 		#questions-remaining-inner {
 			transform: rotateX(180deg);
 		}
-
-		cursor: pointer;
 	}
 
 	#remaining-front {


### PR DESCRIPTION
Some small visual + behavioral polish after the accessibility update:

- Removed splash screen keyboard instructions button and rolled associated screenreader introduction into the start button
- Style adjustments in player to prevent element "shifting" during certain transition animations
- Fixed Next button location, movement, and behavior
- Next button no longer auto focuses, to accommodate above fixes and to prevent feedback live region readback from being interrupted
- Modest adjustments to several elements in the player to improve layout
- Added slight debounce to `focus-me` directive (premature focusing during CSS transitions contributed to element "shifting") 
- Added preconnects for fonts to improve rendering

Tested in Firefox, Chrome, Safari, with and without VoiceOver. VO + Safari has several small issues - including a different tab sequence position for the Next button, and residual "shifting" when the Next button is clicked - but the issues are minor and shouldn't significantly affect non-sighted users.