### PR TITLE
Adds missing update method to score screen

### DIFF
--- a/src/controllers/ctl-scoreScreen.js
+++ b/src/controllers/ctl-scoreScreen.js
@@ -4,6 +4,8 @@ export const ControllerThisOrThatScorescreen = function($scope, $sce) {
 	
 	const materiaCallbacks = {}
 
+	const getHeight = () => Math.ceil(parseFloat(window.getComputedStyle(document.querySelector('html')).height))
+
 	const getQuestionIndex = (qset, id) => {
 		for (let i = 0; i < qset.items.length; i++) {
 			if (qset.items[i].id == id) return i
@@ -21,7 +23,7 @@ export const ControllerThisOrThatScorescreen = function($scope, $sce) {
 		return parseInt((overallDeduction / numIncorrect) * 100)
 	}
 
-	materiaCallbacks.start = (instance, qset, scoreTable, isPreview, qsetVersion) => {
+	materiaCallbacks.update = (qset, scoreTable) => {
 		$scope.$apply(() => {
 			$scope.items = scoreTable.map((question, index) => {
 
@@ -60,6 +62,12 @@ export const ControllerThisOrThatScorescreen = function($scope, $sce) {
 				return item
 			})
 		})
+
+		Materia.ScoreCore.setHeight(getHeight())
+	}
+
+	materiaCallbacks.start = (instance, qset, scoreTable, isPreview, qsetVersion) => {
+		materiaCallbacks.update(qset, scoreTable)
 	}
 
 	Materia.ScoreCore.hideResultsTable()

--- a/src/scoreScreen.test.js
+++ b/src/scoreScreen.test.js
@@ -145,6 +145,7 @@ describe('Score Screen Controller', function() {
 				start: jest.fn(methods => {
 					publicMethods = methods
 				}),
+				setHeight: jest.fn(),
 				// alert: jest.fn(),
 				// cancelSave: jest.fn(),
 				// save: jest.fn().mockImplementation((title, qset) => {


### PR DESCRIPTION
Resolves #58. The score screen would not update when selecting different attempts because the required callback method was not implemented. This PR implements the `update` method, and additionally implements a call to the ScoreCore's `setHeight` method to better scale the score screen based on content.