### PR TITLE
Added question bank value safeguarding

### DIFF
--- a/src/controllers/ctl-creator.js
+++ b/src/controllers/ctl-creator.js
@@ -76,8 +76,14 @@ export const ControllerThisOrThatCreator = function($scope, $timeout, $sanitize,
 				$scope.questionBankVal
 			)
 			if (qset) {
+				// Ensure the question bank value isn't out of bounds when the widget is saved
+				if($scope.questionBankVal > $scope.questions.length) {
+					$scope.questionBankVal = $scope.questions.length
+				}
+
 				return Materia.CreatorCore.save($sanitize($scope.title), qset, 2)
 			}
+
 		} else {
 			Materia.CreatorCore.cancelSave('Please make sure every question is complete')
 
@@ -296,6 +302,11 @@ export const ControllerThisOrThatCreator = function($scope, $timeout, $sanitize,
 
 		$timeout(_noTransition, 660, true)
 		$scope.questions.splice(index, 1)
+
+		// Make sure questionBank value is within bounds after removing a question
+		if($scope.questionBankVal > $scope.questions.length) {
+			$scope.questionBankVal = $scope.questionBankValTemp = $scope.questions.length
+		}
 
 		if ($scope.currIndex === $scope.questions.length) {
 			$timeout(() => _updateIndex('remove'), 200, true)


### PR DESCRIPTION
Essentially added a check on both save and word pair deletion, to update the question bank value if it's higher than that of the question count. This way, the player won't encounter a weird error using invalid question bank data.

Fixes #78 .