### PR TITLE
Style and accessibility tweaks

### DIFF
--- a/src/materia-init/creator/creator.jsx
+++ b/src/materia-init/creator/creator.jsx
@@ -12,7 +12,7 @@ window.addEventListener('drop', (e) => {
 })
 
 // State
-let currentTitle = ''
+let currentTitle = 'My This or That Widget'
 let saver = null
 let promptHandler = null
 let mediaHandler = null
@@ -47,7 +47,7 @@ materiaCallbacks.onSaveClicked = () => {
   }
 
   Materia.CreatorCore.save(
-    currentTitle,
+    currentTitle === '' ? 'My This or That Widget' : currentTitle,
     saverResult,
     saverResult.version
   )

--- a/src/widgets/player/business-game/BusinessGame/BusinessGame.tsx
+++ b/src/widgets/player/business-game/BusinessGame/BusinessGame.tsx
@@ -78,7 +78,7 @@ export default function BusinessGame({
             className={clsx({
               [styles.questionContainer]: true,
               [styles.outro]: doMidPhaseAnims,
-            })}>
+            })} aria-live="polite">
             <h2>{currentQuestion?.questions[0].text}</h2>
           </div>
 

--- a/src/widgets/player/business-game/BusinessGame/BusinessGame.tsx
+++ b/src/widgets/player/business-game/BusinessGame/BusinessGame.tsx
@@ -14,6 +14,27 @@ export default function BusinessGame({
 }: GameProps) {
   // Intro/outro
   const [introClosed, setIntroClosed] = useState(false)
+  const [announcementText, setAnnouncementText] = useState('')
+
+  useEffect(() => {
+    if (leftChoiceState !== 'unpicked') {
+      const stateText = leftChoiceState === 'correct' ? 'CORRECT' : 'INCORRECT'
+      const feedback = leftChoice.options.feedback
+      const announcement = feedback ? `${stateText} ${feedback}` : stateText
+
+      setAnnouncementText('')
+      setTimeout(() => setAnnouncementText(announcement), 100)
+    } else if (rightChoiceState !== 'unpicked') {
+      const stateText = rightChoiceState === 'correct' ? 'CORRECT' : 'INCORRECT'
+      const feedback = rightChoice.options.feedback
+      const announcement = feedback ? `${stateText} ${feedback}` : stateText
+
+      setAnnouncementText('')
+      setTimeout(() => setAnnouncementText(announcement), 100)
+    } else {
+      setAnnouncementText('')
+    }
+  }, [leftChoiceState, rightChoiceState, leftChoice, rightChoice])
 
   // Lightbox
   const [lightboxContent, setLightboxContent] = useState<ReactNode>(null)
@@ -42,6 +63,19 @@ export default function BusinessGame({
 
   return (
     <main className={styles.main}>
+      <div 
+        aria-live="polite" 
+        role="status"
+        style={{
+          position: 'absolute',
+          left: '-10000px',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+        }}>
+        {announcementText}
+      </div>
+
       <BusinessIntro
         hide={introClosed}
         onNext={() => {
@@ -94,7 +128,7 @@ export default function BusinessGame({
               key={leftChoice.id}
               choiceType={leftChoice.options.asset.type}
               mediaUrl={leftChoice.options.asset.value}
-              answerText={leftChoice.text}
+              answerText={leftChoice.options.asset.type != 'text' ? leftChoice.text : leftChoice.options.asset.value}
               answerFeedback={leftChoice.options.feedback}
               onSelect={() => submitQuestion('left')}
               state={leftChoiceState}
@@ -108,7 +142,7 @@ export default function BusinessGame({
               key={rightChoice.id}
               choiceType={rightChoice.options.asset.type}
               mediaUrl={rightChoice.options.asset.value}
-              answerText={rightChoice.text}
+              answerText={rightChoice.options.asset.type != 'text' ? rightChoice.text : rightChoice.options.asset.value}
               answerFeedback={rightChoice.options.feedback}
               onSelect={() => submitQuestion('right')}
               state={rightChoiceState}

--- a/src/widgets/player/business-game/components/BusinessChoiceContent/BusinessChoiceContent.tsx
+++ b/src/widgets/player/business-game/components/BusinessChoiceContent/BusinessChoiceContent.tsx
@@ -6,10 +6,11 @@ interface BusinessChoiceContentProps {
   disabled: boolean,
   onHover: (hovered: boolean) => void,
   children: ReactNode,
+  onFocus: (focused: boolean) => void,
 }
 
 export default function BusinessChoiceContent(
-  { onSelect, disabled, onHover, children }: BusinessChoiceContentProps,
+  { onSelect, disabled, onHover, children, onFocus }: BusinessChoiceContentProps,
 ) {
   return (
     <button
@@ -17,7 +18,9 @@ export default function BusinessChoiceContent(
       onClick={onSelect}
       disabled={disabled}
       onMouseEnter={() => onHover(true)}
-      onMouseLeave={() => onHover(false)}>
+      onMouseLeave={() => onHover(false)}
+	  onFocus={() => onFocus(true)}
+	  onBlur={() => onFocus(false)}>
       {children}
     </button>
   )

--- a/src/widgets/player/business-game/components/BusinessChoiceContent/BusinessChoiceContent.tsx
+++ b/src/widgets/player/business-game/components/BusinessChoiceContent/BusinessChoiceContent.tsx
@@ -7,10 +7,11 @@ interface BusinessChoiceContentProps {
   onHover: (hovered: boolean) => void,
   children: ReactNode,
   onFocus: (focused: boolean) => void,
+  answerText?: string,
 }
 
 export default function BusinessChoiceContent(
-  { onSelect, disabled, onHover, children, onFocus }: BusinessChoiceContentProps,
+  { onSelect, disabled, onHover, children, onFocus, answerText = '' }: BusinessChoiceContentProps,
 ) {
   return (
     <button
@@ -20,7 +21,8 @@ export default function BusinessChoiceContent(
       onMouseEnter={() => onHover(true)}
       onMouseLeave={() => onHover(false)}
 	  onFocus={() => onFocus(true)}
-	  onBlur={() => onFocus(false)}>
+	  onBlur={() => onFocus(false)}
+      aria-label={answerText ? `Select answer: ${answerText}` : undefined}>
       {children}
     </button>
   )

--- a/src/widgets/player/business-game/components/BusinessChoiceContent/styles.module.css
+++ b/src/widgets/player/business-game/components/BusinessChoiceContent/styles.module.css
@@ -4,4 +4,8 @@
   width: 100%;
   height: 100%;
   text-align: center;
+
+  @media (max-width: 660px) {
+    height: auto;
+  }
 }

--- a/src/widgets/player/business-game/components/BusinessChoiceContentWithButton/BusinessChoiceContentWithButton.tsx
+++ b/src/widgets/player/business-game/components/BusinessChoiceContentWithButton/BusinessChoiceContentWithButton.tsx
@@ -7,10 +7,11 @@ interface BusinessChoiceContentWithButtonProps {
   disabled: boolean,
   onHover: (hovered: boolean) => void,
   children: ReactNode,
+  answerText?: string,
 }
 
 export default function BusinessChoiceContentWithButton(
-  { onSelect, disabled, onHover, children }: BusinessChoiceContentWithButtonProps,
+  { onSelect, disabled, onHover, children, answerText = '' }: BusinessChoiceContentWithButtonProps,
 ) {
   return (
     <div className={styles.contentContainer}>
@@ -21,7 +22,8 @@ export default function BusinessChoiceContentWithButton(
         onClick={onSelect}
         disabled={disabled}
         onMouseEnter={() => onHover(true)}
-        onMouseLeave={() => onHover(false)}>
+        onMouseLeave={() => onHover(false)}
+        aria-label={answerText ? `Select answer: ${answerText}` : undefined}>
         Select
       </BusinessButton>
     </div>

--- a/src/widgets/player/business-game/components/BusinessGameChoice/BusinessGameChoice.tsx
+++ b/src/widgets/player/business-game/components/BusinessGameChoice/BusinessGameChoice.tsx
@@ -26,6 +26,7 @@ export default function BusinessGameChoice({
   choiceType, mediaUrl, answerText, answerFeedback, onSelect, state, highlightCorrectOnFail, disabled, animationState, openLightbox,
 }: BusinessGameChoiceProps) {
   const [hovered, setHovered] = useState(false)
+  const [focused, setFocused] = useState(false)
 
   // Render media
   let mediaRender = null
@@ -38,7 +39,8 @@ export default function BusinessGameChoice({
       <BusinessChoiceContent
         onSelect={onSelect}
         disabled={disabled}
-        onHover={setHovered}>
+        onHover={setHovered}
+		onFocus={setFocused}>
         <img className={styles.imgChoice} src={mediaUrl} alt={answerText} />
       </BusinessChoiceContent>
     )
@@ -89,7 +91,8 @@ export default function BusinessGameChoice({
       <BusinessChoiceContent
         onSelect={onSelect}
         disabled={disabled}
-        onHover={setHovered}>
+        onHover={setHovered}
+		onFocus={setFocused}>
         <p>{mediaUrl}</p>
       </BusinessChoiceContent>
     )
@@ -100,6 +103,7 @@ export default function BusinessGameChoice({
       className={clsx({
         [styles.choiceBorder]: true,
         [styles.hovered]: hovered,
+		[styles.focused]: focused,
       })}
       >
       <div

--- a/src/widgets/player/business-game/components/BusinessGameChoice/BusinessGameChoice.tsx
+++ b/src/widgets/player/business-game/components/BusinessGameChoice/BusinessGameChoice.tsx
@@ -40,7 +40,8 @@ export default function BusinessGameChoice({
         onSelect={onSelect}
         disabled={disabled}
         onHover={setHovered}
-		onFocus={setFocused}>
+		onFocus={setFocused}
+        answerText={answerText}>
         <img className={styles.imgChoice} src={mediaUrl} alt={answerText} />
       </BusinessChoiceContent>
     )
@@ -53,7 +54,8 @@ export default function BusinessGameChoice({
       <BusinessChoiceContentWithButton
         onSelect={onSelect}
         disabled={disabled}
-        onHover={setHovered}>
+        onHover={setHovered}
+        answerText={answerText}>
         <iframe
           className={styles.videoFrame}
           width="100%"
@@ -72,7 +74,8 @@ export default function BusinessGameChoice({
       <BusinessChoiceContentWithButton
         onSelect={onSelect}
         disabled={disabled}
-        onHover={setHovered}>
+        onHover={setHovered}
+        answerText={answerText}>
         <figcaption className={styles.audioDescription}>
           <p className={styles.audioDescLabel}>AUDIO DESCRIPTION</p>
           <p>{answerText}</p>
@@ -92,7 +95,8 @@ export default function BusinessGameChoice({
         onSelect={onSelect}
         disabled={disabled}
         onHover={setHovered}
-		onFocus={setFocused}>
+		onFocus={setFocused}
+        answerText={answerText}>
         <p>{mediaUrl}</p>
       </BusinessChoiceContent>
     )

--- a/src/widgets/player/business-game/components/BusinessGameChoice/styles.module.css
+++ b/src/widgets/player/business-game/components/BusinessGameChoice/styles.module.css
@@ -21,6 +21,11 @@
 
   &.hovered {
     --gradient-color-1: #5E7FBA;
+    --gradient-color-2: #41577e;
+  }
+
+  &.focused {
+    --gradient-color-1: #5E7FBA;
     --gradient-color-2: #41577e
   }
 

--- a/src/widgets/player/business-game/components/BusinessIntro/BusinessIntro.tsx
+++ b/src/widgets/player/business-game/components/BusinessIntro/BusinessIntro.tsx
@@ -2,6 +2,7 @@ import InsetBox from '../../../../creator/components/InsetBox/InsetBox'
 import { BusinessButton } from '../../../../shared/components/BusinessButton/BusinessButton'
 import styles from './styles.module.css'
 import clsx from 'clsx'
+import { useRef, useEffect } from 'react'
 
 interface BusinessIntroProps {
   hide: boolean,
@@ -9,12 +10,21 @@ interface BusinessIntroProps {
 }
 
 export default function BusinessIntro({ hide, onNext }: BusinessIntroProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!hide && buttonRef.current) {
+      buttonRef.current.focus()
+    }
+  }, [hide])
+
   return (
     <div
       className={clsx({
         [styles.introScreenContainer]: true,
         [styles.hide]: hide,
-      })}>
+      })}
+      aria-hidden={hide}>
       <div className={styles.introScreen}>
         <div className={styles.introInnerContainer}>
           <img className={styles.logo} src="assets/logo.svg" alt="" />
@@ -25,10 +35,12 @@ export default function BusinessIntro({ hide, onNext }: BusinessIntroProps) {
         </div>
         <InsetBox className={styles.startButtonContainer}>
           <BusinessButton
+            ref={buttonRef}
             preIcon="assets/play.svg"
             onClick={() => {
               onNext()
-            }}>
+            }}
+            tabIndex={hide ? -1 : 0}>
             Start Assessment
           </BusinessButton>
         </InsetBox>

--- a/src/widgets/player/business-game/components/BusinessOutro/BusinessOutro.tsx
+++ b/src/widgets/player/business-game/components/BusinessOutro/BusinessOutro.tsx
@@ -2,6 +2,7 @@ import styles from './styles.module.css'
 import clsx from 'clsx'
 import InsetBox from '../../../../creator/components/InsetBox/InsetBox'
 import { BusinessButton } from '../../../../shared/components/BusinessButton/BusinessButton'
+import { useRef, useEffect } from 'react'
 
 interface BusinessOutroProps {
   hide: boolean,
@@ -9,12 +10,21 @@ interface BusinessOutroProps {
 }
 
 export default function BusinessOutro({ hide, onNext }: BusinessOutroProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!hide && buttonRef.current) {
+      buttonRef.current.focus()
+    }
+  }, [hide])
+
   return (
     <div
       className={clsx({
         [styles.outroScreenContainer]: true,
         [styles.hide]: hide,
-      })}>
+      })}
+      aria-hidden={hide}>
       <InsetBox className={styles.outroScreen}>
         <div className={styles.yellowBar} />
         <div className={styles.outerScreenInnerContainer}>
@@ -23,11 +33,14 @@ export default function BusinessOutro({ hide, onNext }: BusinessOutroProps) {
           </div>
           <h2>Assessment Complete</h2>
           <BusinessButton
+            ref={buttonRef}
             fill
             postIcon="assets/right-arrow.svg"
             onClick={() => {
               onNext()
-            }}>
+            }}
+            tabIndex={hide ? -1 : 0}
+            aria-label="Assessment complete. View your results on the score screen.">
             View Results
           </BusinessButton>
         </div>

--- a/src/widgets/player/whimsical-game/WhimsicalGame/WhimsicalGame.tsx
+++ b/src/widgets/player/whimsical-game/WhimsicalGame/WhimsicalGame.tsx
@@ -26,6 +26,27 @@ export default function WhimsicalGame({
   const [lightboxContent, setLightboxContent] = useState<ReactNode | null>(null)
   const [lightboxClosing, setLightboxClosing] = useState(false)
   const [tutorialModalOpen, setTutorialModalOpen] = useState(false)
+  const [announcementText, setAnnouncementText] = useState('')
+
+  useEffect(() => {
+    if (leftChoiceState !== 'unpicked') {
+      const stateText = leftChoiceState === 'correct' ? 'Correct!' : 'Incorrect!'
+      const feedback = leftChoice.options.feedback
+      const announcement = feedback ? `${stateText} ${feedback}` : stateText
+
+      setAnnouncementText('')
+      setTimeout(() => setAnnouncementText(announcement), 100)
+    } else if (rightChoiceState !== 'unpicked') {
+      const stateText = rightChoiceState === 'correct' ? 'Correct!' : 'Incorrect!'
+      const feedback = rightChoice.options.feedback
+      const announcement = feedback ? `${stateText} ${feedback}` : stateText
+
+      setAnnouncementText('')
+      setTimeout(() => setAnnouncementText(announcement), 100)
+    } else {
+      setAnnouncementText('')
+    }
+  }, [leftChoiceState, rightChoiceState, leftChoice, rightChoice])
 
   // Calculate hand states
   useEffect(() => {
@@ -54,7 +75,18 @@ export default function WhimsicalGame({
 
   return (
     <main className={styles.main}>
-      <div aria-live="assertive" role="status" />
+      <div 
+        aria-live="polite" 
+        role="status"
+        style={{
+          position: 'absolute',
+          left: '-10000px',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+        }}>
+        {announcementText}
+      </div>
 
       <SplashScreen
         isRaised={gameInProgress}
@@ -120,7 +152,7 @@ export default function WhimsicalGame({
               side="left"
               choiceType={leftChoice.options.asset.type}
               mediaUrl={leftChoice.options.asset.value}
-              answerText={leftChoice.text}
+              answerText={leftChoice.options.asset.type != 'text' ? leftChoice.text : leftChoice.options.asset.value}
               answerFeedback={leftChoice.options.feedback}
               onHover={setLeftChoiceHovered}
               onSelect={() => { submitQuestion('left') }}
@@ -133,7 +165,7 @@ export default function WhimsicalGame({
               side="right"
               choiceType={rightChoice.options.asset.type}
               mediaUrl={rightChoice.options.asset.value}
-              answerText={rightChoice.text}
+              answerText={rightChoice.options.asset.type != 'text' ? rightChoice.text : rightChoice.options.asset.value}
               answerFeedback={rightChoice.options.feedback}
               onHover={setRightChoiceHovered}
               onSelect={() => { submitQuestion('right') }}

--- a/src/widgets/player/whimsical-game/WhimsicalGame/WhimsicalGame.tsx
+++ b/src/widgets/player/whimsical-game/WhimsicalGame/WhimsicalGame.tsx
@@ -83,13 +83,14 @@ export default function WhimsicalGame({
             })}>
             <button
               className={styles.inGameInstructionsButton}
+              aria-label="Open Keyboard Controls"
               onClick={() => { setTutorialModalOpen(true) }}>
               ?
             </button>
             <h2 className={clsx({
               [styles.questionText]: true,
               [styles.lowered]: doMidPhaseAnims,
-            })}>
+            })} aria-live="polite">
               {currentQuestion.questions[0].text}
             </h2>
             <div
@@ -97,7 +98,11 @@ export default function WhimsicalGame({
               onClick={() => {}}
               onMouseEnter={() => {}}
               onMouseLeave={() => {}}>
-              <div className={styles.puckContainer}>
+              <div
+                className={styles.puckContainer}
+                tabIndex={0}
+                aria-label={`Question ${currentQuestionIndex + 1} of ${totalNumberOfQuestions}: ${currentQuestion.questions[0].text}`}
+            >
                 <p className={clsx([styles.puck, styles.front])}>{currentQuestionIndex + 1}</p>
                 <p className={clsx([styles.puck, styles.back])}>{`of ${totalNumberOfQuestions}`}</p>
               </div>

--- a/src/widgets/player/whimsical-game/WhimsicalGame/styles.module.css
+++ b/src/widgets/player/whimsical-game/WhimsicalGame/styles.module.css
@@ -61,7 +61,6 @@ body {
     height: auto;
     max-height: 220px;
     font-size: 1em;
-    overflow-y: auto;
   }
 }
 

--- a/src/widgets/player/whimsical-game/WhimsicalGame/styles.module.css
+++ b/src/widgets/player/whimsical-game/WhimsicalGame/styles.module.css
@@ -47,7 +47,7 @@ body {
   width: 100%;
   gap: 20px;
   text-align: center;
-  margin-top: 2rem;
+  margin-top: 3rem;
   z-index: 10;
   translate: 0 -200%;
   transition: translate 0.75s;
@@ -57,8 +57,11 @@ body {
     translate: 0 0;
   }
 
-  @media (max-width: 900px)  {
-    margin-top: 30px;
+  @media (max-width: 660px) {
+    height: auto;
+    max-height: 220px;
+    font-size: 1em;
+    overflow-y: auto;
   }
 }
 

--- a/src/widgets/player/whimsical-game/components/ChoiceContent/ChoiceContent.tsx
+++ b/src/widgets/player/whimsical-game/components/ChoiceContent/ChoiceContent.tsx
@@ -10,6 +10,7 @@ interface ChoiceContentProps {
   onSelect: () => void,
   state: ChoiceState,
   answerFeedback: string,
+  answerText?: string,
   expandable?: boolean,
   onExpand?: () => void,
   children: ReactNode,
@@ -20,6 +21,7 @@ export default function ChoiceContent({
   onSelect,
   state,
   answerFeedback,
+  answerText = '',
   expandable = false,
   onExpand = () => {},
   children,
@@ -34,6 +36,7 @@ export default function ChoiceContent({
         onMouseLeave={() => onHover(false)}
         onClick={onSelect}
         disabled={state != 'unpicked'}
+        aria-label={answerText ? `Select answer: ${answerText}` : undefined}
       >
         {children}
         <ChoiceOverlay state={state} answerFeedback={answerFeedback} />

--- a/src/widgets/player/whimsical-game/components/ChoiceContent/ChoiceContent.tsx
+++ b/src/widgets/player/whimsical-game/components/ChoiceContent/ChoiceContent.tsx
@@ -33,6 +33,7 @@ export default function ChoiceContent({
         onMouseEnter={() => onHover(true)}
         onMouseLeave={() => onHover(false)}
         onClick={onSelect}
+        disabled={state != 'unpicked'}
       >
         {children}
         <ChoiceOverlay state={state} answerFeedback={answerFeedback} />
@@ -45,6 +46,7 @@ export default function ChoiceContent({
           icon="assets/expand.svg"
           onClick={onExpand}
           square
+		  aria-label="Click to enlarge this content in a modal"
         />
       )}
     </div>

--- a/src/widgets/player/whimsical-game/components/ChoiceContent/styles.module.css
+++ b/src/widgets/player/whimsical-game/components/ChoiceContent/styles.module.css
@@ -21,13 +21,17 @@
   width: 100%;
   height: 100%;
   cursor: pointer;
-  background-color: var(--whimsical-frame-bg-color);
   color: black;
+  background: var(--whimsical-frame-text-bg-color);
 
   & img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  &:disabled {
+	cursor: auto;
   }
 }
 

--- a/src/widgets/player/whimsical-game/components/ChoiceContentWithButton/ChoiceContentWithButton.tsx
+++ b/src/widgets/player/whimsical-game/components/ChoiceContentWithButton/ChoiceContentWithButton.tsx
@@ -37,7 +37,7 @@ export default function ChoiceContentWithButton({
         )}
       </div>
       <div className={styles.choiceButtons}>
-        <Button style="secondary" onClick={onSelect}>Select</Button>
+        <Button style="secondary" onClick={onSelect} disabled={state != 'unpicked'}>Select</Button>
       </div>
       <ChoiceOverlay state={state} answerFeedback={answerFeedback} />
     </div>

--- a/src/widgets/player/whimsical-game/components/ChoiceContentWithButton/ChoiceContentWithButton.tsx
+++ b/src/widgets/player/whimsical-game/components/ChoiceContentWithButton/ChoiceContentWithButton.tsx
@@ -10,13 +10,14 @@ interface ChoiceContentWithButtonProps {
   onSelect: () => void,
   state: ChoiceState,
   answerFeedback: string,
+  answerText?: string,
   expandable: boolean,
   onExpand?: () => void,
   children: ReactNode,
 }
 
 export default function ChoiceContentWithButton({
-  onHover, onSelect, state, answerFeedback, expandable, onExpand, children,
+  onHover, onSelect, state, answerFeedback, answerText = '', expandable, onExpand, children,
 }: ChoiceContentWithButtonProps) {
   return (
     <div
@@ -37,7 +38,7 @@ export default function ChoiceContentWithButton({
         )}
       </div>
       <div className={styles.choiceButtons}>
-        <Button style="secondary" onClick={onSelect} disabled={state != 'unpicked'}>Select</Button>
+        <Button style="secondary" onClick={onSelect} disabled={state != 'unpicked'} aria-label={answerText ? `Select answer: ${answerText}` : undefined}>Select</Button>
       </div>
       <ChoiceOverlay state={state} answerFeedback={answerFeedback} />
     </div>

--- a/src/widgets/player/whimsical-game/components/GameChoice/GameChoice.tsx
+++ b/src/widgets/player/whimsical-game/components/GameChoice/GameChoice.tsx
@@ -61,6 +61,7 @@ export default function GameChoice({
         onSelect={onSelect}
         state={state}
         answerFeedback={answerFeedback}
+        answerText={answerText}
         expandable
         onExpand={() => openLightbox(lightboxRender)}>
         <img src={mediaUrl} alt={answerText} draggable={false} />
@@ -76,6 +77,7 @@ export default function GameChoice({
         onSelect={onSelect}
         state={state}
         answerFeedback={answerFeedback}
+        answerText={answerText}
         expandable
         onExpand={() => openLightbox(lightboxRender)}>
         <iframe
@@ -94,6 +96,7 @@ export default function GameChoice({
         onSelect={onSelect}
         state={state}
         answerFeedback={answerFeedback}
+        answerText={answerText}
         expandable={false}>
         <figure className={styles.audioFigure}>
           <audio controls src={mediaUrl}>
@@ -113,7 +116,8 @@ export default function GameChoice({
         onHover={onHover}
         onSelect={onSelect}
         state={state}
-        answerFeedback={answerFeedback}>
+        answerFeedback={answerFeedback}
+        answerText={answerText}>
         <div className={styles.textChoice}>
           <p>{mediaUrl}</p>
         </div>

--- a/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
+++ b/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
@@ -38,20 +38,20 @@
     flex-basis: 90%;
     max-width: 480px;
     aspect-ratio: var(--image-aspect-ratio);
-    padding: 5.25% 5% 5.75% 5%;
+    padding: 2rem 1.75rem;
     background-size: contain;
     background-repeat: no-repeat;
     background-position: center;
 
     &.unpicked {
-      background-color: #f8a844;
+      background-color: var(--whimsical-frame-bg-color);
       mask-image: url('/src/assets/player-frame.svg');
       mask-size: contain;
       mask-repeat: no-repeat;
       mask-position: center;
 
       &:hover {
-        background-color: #ffc280;
+        background-color: var(--whimsical-frame-highlight-color);
       }
     }
 
@@ -104,6 +104,12 @@
     &.right {
       animation: bouncy-out-thatimg 0.5s forwards;
     }
+  }
+}
+
+.container:has(button:focus) {
+  .frame.unpicked {
+    background-color: var(--whimsical-frame-highlight-color);
   }
 }
 

--- a/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
+++ b/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
@@ -37,6 +37,7 @@
     display: flex;
     flex-basis: 90%;
     max-width: 480px;
+    min-height: 0; /* addresses flexbox child collapse bug in Safari */
     aspect-ratio: var(--image-aspect-ratio);
     padding: 2rem 1.75rem;
     background-size: contain;

--- a/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
+++ b/src/widgets/player/whimsical-game/components/GameChoice/styles.module.css
@@ -132,6 +132,7 @@
   flex-direction: column;
   justify-content: center;
   gap: 1em;
+  width: 100%;
   padding: 2em 0.5em;
   background-color: #fcf3e3;
   color: #000;

--- a/src/widgets/player/whimsical-game/components/Hands/styles.module.css
+++ b/src/widgets/player/whimsical-game/components/Hands/styles.module.css
@@ -64,3 +64,9 @@
     }
   }
 }
+
+@media (max-width: 660px) {
+  .hands {
+    visibility: hidden;
+  }
+}

--- a/src/widgets/player/whimsical-game/components/SplashScreen/SplashScreen.tsx
+++ b/src/widgets/player/whimsical-game/components/SplashScreen/SplashScreen.tsx
@@ -1,6 +1,7 @@
 import styles from './styles.module.css'
 import clsx from 'clsx'
 import { Button } from '../Button/Button'
+import { useRef, useEffect } from 'react'
 
 type SplashScreenProps = {
   closeIntro: () => void,
@@ -13,6 +14,14 @@ export default function SplashScreen({
   isRaised,
   mode,
 }: SplashScreenProps) {
+  const endButtonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (mode === 'end' && !isRaised && endButtonRef.current) {
+      endButtonRef.current.focus()
+    }
+  }, [mode, isRaised])
+
   return (
     <div className={clsx({
       [styles.splashScreen]: true,
@@ -50,8 +59,9 @@ export default function SplashScreen({
 
         {mode === 'end' && (
           <Button
+            ref={endButtonRef}
             className={styles.startButton}
-            aria-label="TODO CHANGE"
+            aria-label="Game complete! Continue to the score screen to view your results."
             aria-hidden={false}
             size="l"
             onClick={closeIntro}>

--- a/src/widgets/player/whimsical-globals.css
+++ b/src/widgets/player/whimsical-globals.css
@@ -7,6 +7,10 @@ body {
   --gold: #FFA30FFF;
   --gold-light: #FFB743FF;
 
+  --whimsical-frame-bg-color: #f8a844;
+  --whimsical-frame-highlight-color: #ffc280;
+  --whimsical-frame-text-bg-color: rgba(251, 242, 219, 1);
+
   --chunky-font: 'Sigmar One';
   --regular-font: 'Buenard', serif;
   --bounce-timing: cubic-bezier(0.34, 1.56, 0.64, 1);

--- a/src/widgets/score_screen/score-screen-globals.css
+++ b/src/widgets/score_screen/score-screen-globals.css
@@ -310,11 +310,9 @@ div.content-frame {
 		position: relative;
 		width: calc(100% - 100px);
 		padding: 70px 50px 50px 50px;
-		background-image:	url('/src/assets/score-screen-curtains-top.svg'),
-							url('/src/assets/score-screen-curtains-side.svg'),
-							url('/src/assets/score-screen-curtains-side-mirrored.svg');
-		background-repeat: repeat-x, repeat-y, repeat-y;
-		background-position: calc(50% - 5px) -5px, -25px 0, calc(100% + 25px) 0;
+		background-image: url('/src/assets/score-screen-curtains-top.svg');
+		background-repeat: repeat-x;
+		background-position: calc(50% - 5px) -5px;
 
 		background-color: var(--whimsical-background-color);
 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -38,7 +38,15 @@ const cssLoader = {
 		"style-loader",
 		{
 			loader: "css-loader",
-			options: { esModule: false },
+			options: { 
+				esModule: false,
+				modules: {
+					auto: true,
+					localIdentName: process.env.NODE_ENV === 'production'
+						? '[hash:base64:5]'
+						: '[path][name]__[local]'
+				}
+			},
 		},
 		{
 			loader: "postcss-loader",


### PR DESCRIPTION
- Minor improvements to whimsical mode styling
- Added focus styles for choice selection in both themes
- Re-implemented live region updates for both themes
- Improved readout of choice selection via `aria-label`s
- Fixed business mode visibility of start/end options in the tab tree
- Added focus behavior to outro screens in both themes
- Webpack now emits css selectors in a (slightly more) human-readable format in development